### PR TITLE
Speed up certificate generation time by reusing publicKey and priateKey.

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -1,7 +1,6 @@
 package goproxy
 
 import (
-	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
@@ -73,16 +72,12 @@ func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 	if csprng, err = NewCounterEncryptorRandFromKey(ca.PrivateKey, hash); err != nil {
 		return
 	}
-	var certpriv *rsa.PrivateKey
-	if certpriv, err = rsa.GenerateKey(&csprng, 2048); err != nil {
-		return
-	}
 	var derBytes []byte
-	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, &certpriv.PublicKey, ca.PrivateKey); err != nil {
+	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, x509ca.PublicKey, ca.PrivateKey); err != nil {
 		return
 	}
 	return &tls.Certificate{
 		Certificate: [][]byte{derBytes, ca.Certificate[0]},
-		PrivateKey:  certpriv,
+		PrivateKey:  ca.PrivateKey,
 	}, nil
 }


### PR DESCRIPTION
Reduce function `signHost` execution time from N*100 ms to N ms.